### PR TITLE
Print first packet number of the file's stream

### DIFF
--- a/core/Dispatcher.py
+++ b/core/Dispatcher.py
@@ -80,6 +80,7 @@ class Dispatcher:
                         file.source = stream.ipSrc
                         file.destination = stream.ipDst
                         file.firstPacketNumber = stream.firstPacketNumber
+                        file.pcapFile = stream.pcapFile
                         file.fileEnding = self.pm.dataRecognizers[datarecognizer].fileEnding
                         file.type = self.pm.dataRecognizers[datarecognizer].dataCategory
                         if stream.tsFirstPacket:

--- a/core/Dispatcher.py
+++ b/core/Dispatcher.py
@@ -79,6 +79,7 @@ class Dispatcher:
                         file = FileObject(payload[occ[0]:occ[1]])
                         file.source = stream.ipSrc
                         file.destination = stream.ipDst
+                        file.firstPacketNumber = stream.firstPacketNumber
                         file.fileEnding = self.pm.dataRecognizers[datarecognizer].fileEnding
                         file.type = self.pm.dataRecognizers[datarecognizer].dataCategory
                         if stream.tsFirstPacket:

--- a/core/Files/FileManager.py
+++ b/core/Files/FileManager.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+import csv
+
 __author__ = 'Viktor Winkelmann'
 
 import sys
@@ -54,5 +56,10 @@ class FileManager(Thread):
             with open(path + filename, 'wb') as outfile:
                 outfile.write(file.data)
                 Utils.printl("Wrote file: %s%s" % (path, filename))
+
+            with open(self.outputdir + '/files.csv', 'ab') as outcsv:
+                csvwriter = csv.writer(outcsv, delimiter=',')
+                csvwriter.writerow([file.pcapFile, file.firstPacketNumber, filename, file.fileEnding,
+                                    file.md5.hexdigest(), file.source, file.destination, file.timestamp])
 
             self.files.task_done()

--- a/core/Files/FileManager.py
+++ b/core/Files/FileManager.py
@@ -38,7 +38,8 @@ class FileManager(Thread):
                 self.files.task_done()
                 continue
 
-            path = "%s/%ss/%s_%s/%s/" % (self.outputdir, file.type, file.source, file.destination, file.timestamp)
+            path = "%s/%ss/%s_%s/%s_%s/" % (self.outputdir, file.type, file.source, file.destination, file.timestamp,
+                                            file.firstPacketNumber)
             if not os.path.exists(path):
                 os.makedirs(path)
 

--- a/core/Files/FileObject.py
+++ b/core/Files/FileObject.py
@@ -12,6 +12,7 @@ class FileObject(object):
         self._timestamp = 'unknown'
         self.type = 'unknown'
         self.fileEnding = 'unknown'
+        self.firstPacketNumber = None
 
     @property
     def name(self):

--- a/core/Files/FileObject.py
+++ b/core/Files/FileObject.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+import hashlib
+
 __author__ = 'Viktor Winkelmann'
 
 import datetime
@@ -6,9 +8,11 @@ import datetime
 class FileObject(object):
     def __init__(self, data):
         self.data = data
+        self.md5 = hashlib.md5(data)
         self._name = None
         self.source = 'unknown'
         self.destination = 'unknown'
+        self.pcapFile = 'unknown'
         self._timestamp = 'unknown'
         self.type = 'unknown'
         self.fileEnding = 'unknown'

--- a/core/Streams/PacketStream.py
+++ b/core/Streams/PacketStream.py
@@ -6,11 +6,12 @@ from abc import ABCMeta, abstractmethod
 class PacketStream:
     __metaclass__ = ABCMeta
 
-    def __init__(self, ipSrc, portSrc, ipDst, portDst):
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
         self.ipSrc = ipSrc
         self.portSrc = portSrc
         self.ipDst = ipDst
         self.portDst = portDst
+        self.firstPacketNumber = firstPacketNumber
         self.infos = "%s:%s to %s:%s" % (ipSrc, portSrc, ipDst, portDst)
         self.protocol = 'unknown protocol'
         self.tsFirstPacket = None

--- a/core/Streams/PacketStream.py
+++ b/core/Streams/PacketStream.py
@@ -6,12 +6,13 @@ from abc import ABCMeta, abstractmethod
 class PacketStream:
     __metaclass__ = ABCMeta
 
-    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber, pcapFile):
         self.ipSrc = ipSrc
         self.portSrc = portSrc
         self.ipDst = ipDst
         self.portDst = portDst
         self.firstPacketNumber = firstPacketNumber
+        self.pcapFile = pcapFile
         self.infos = "%s:%s to %s:%s" % (ipSrc, portSrc, ipDst, portDst)
         self.protocol = 'unknown protocol'
         self.tsFirstPacket = None

--- a/core/Streams/StreamBuilder.py
+++ b/core/Streams/StreamBuilder.py
@@ -69,7 +69,7 @@ class StreamBuilder:
             openUdpStreams = []
 
             print '  Size of file %s: %.2f mb' % (pcapfile, fsize / 1000000)
-            for ts, complete, rawpacket in packets:
+            for packetNumber, (ts, complete, rawpacket) in enumerate(packets, 1):
 
                 if not complete:
                     caplenError = True
@@ -105,7 +105,7 @@ class StreamBuilder:
                             continue
 
                         tcpStream = TCPStream(socket.inet_ntoa(ip.src), packet.sport,
-                                              socket.inet_ntoa(ip.dst), packet.dport)
+                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber)
                         openTcpStreams.append(tcpStream)
 
                     # add packet to currently referenced stream
@@ -132,7 +132,7 @@ class StreamBuilder:
                     # no matching open stream found, create new stream
                     if udpStream is None or udpStream.closed:
                         udpStream = UDPStream(socket.inet_ntoa(ip.src), packet.sport,
-                                              socket.inet_ntoa(ip.dst), packet.dport)
+                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber)
                         openUdpStreams.append(udpStream)
 
                     else:

--- a/core/Streams/StreamBuilder.py
+++ b/core/Streams/StreamBuilder.py
@@ -105,7 +105,7 @@ class StreamBuilder:
                             continue
 
                         tcpStream = TCPStream(socket.inet_ntoa(ip.src), packet.sport,
-                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber)
+                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber, pcapfile)
                         openTcpStreams.append(tcpStream)
 
                     # add packet to currently referenced stream
@@ -132,7 +132,7 @@ class StreamBuilder:
                     # no matching open stream found, create new stream
                     if udpStream is None or udpStream.closed:
                         udpStream = UDPStream(socket.inet_ntoa(ip.src), packet.sport,
-                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber)
+                                              socket.inet_ntoa(ip.dst), packet.dport, packetNumber, pcapfile)
                         openUdpStreams.append(udpStream)
 
                     else:

--- a/core/Streams/TCPStream.py
+++ b/core/Streams/TCPStream.py
@@ -7,8 +7,8 @@ from PacketStream import *
 import dpkt
 
 class TCPStream(PacketStream):
-    def __init__(self, ipSrc, portSrc, ipDst, portDst):
-        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst)
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
+        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber)
 
         self.packets = dict()
 

--- a/core/Streams/TCPStream.py
+++ b/core/Streams/TCPStream.py
@@ -7,8 +7,8 @@ from PacketStream import *
 import dpkt
 
 class TCPStream(PacketStream):
-    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
-        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber)
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber, pcapFile):
+        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber, pcapFile)
 
         self.packets = dict()
 

--- a/core/Streams/UDPStream.py
+++ b/core/Streams/UDPStream.py
@@ -5,8 +5,8 @@ from PacketStream import *
 import dpkt
 
 class UDPStream(PacketStream):
-    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
-        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber)
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber, pcapFile):
+        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber, pcapFile)
 
         self.packets = []
         self.tsLastPacket = None

--- a/core/Streams/UDPStream.py
+++ b/core/Streams/UDPStream.py
@@ -5,8 +5,8 @@ from PacketStream import *
 import dpkt
 
 class UDPStream(PacketStream):
-    def __init__(self, ipSrc, portSrc, ipDst, portDst):
-        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst)
+    def __init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber):
+        PacketStream.__init__(self, ipSrc, portSrc, ipDst, portDst, firstPacketNumber)
 
         self.packets = []
         self.tsLastPacket = None


### PR DESCRIPTION
- Add enumeration for dpkt.pcap.Reader() iteration.
- Add firstPacketNumber attribute to PacketStream (and it's inheritors), and to FileObject.
- Pass the pcap enumeration to the PacketStream in the constructor as the first packet number.
- Print the firstPacketNumber to the uppermost folder (in the FileManager object).